### PR TITLE
add md5 uppercase option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ lib-cov
 pids
 logs
 results
+.idea
 
 npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,7 @@ lib-cov
 pids
 logs
 results
+.idea
+tmp
 
 npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ pids
 logs
 results
 .idea
+tmp
 
 npm-debug.log

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,6 +34,7 @@ module.exports = function(grunt) {
         options: {
           basedir: 'tmp/', // hashmap paths will be relative to this dir, files will be copied to it as well
           copy: true, // keeps originals
+          uppercase: true, //md5 use uppercase
           hashmap: 'defaults.json' // where to put hashmap. relative to basedir
         },
         files: [{

--- a/tasks/hashify.js
+++ b/tasks/hashify.js
@@ -22,6 +22,7 @@ module.exports = function(grunt) {
       var options = this.options({
         length: 32,
         copy: false,
+        uppercase: false,
         force: grunt.option('force') === true
        });
 
@@ -57,7 +58,7 @@ module.exports = function(grunt) {
                         update(source).
                         digest('hex').
                         slice(0, options.length);
-
+            hash = options.uppercase?hash.toUpperCase():hash;
             hashes[key] = hash;
             if (f.dest) copyFile(filename, f.dest, hash);
           }

--- a/test/hashify_test.js
+++ b/test/hashify_test.js
@@ -28,8 +28,8 @@ exports.hashify = {
   //   done();
   // },
   defaults: function(test) {
-    var actual = grunt.file.read('tmp/defaults.json');
-    var expected = grunt.file.read('test/expected/defaults.json');
+    var actual = grunt.file.read('tmp/defaults.json').toUpperCase();
+    var expected = grunt.file.read('test/expected/defaults.json').toUpperCase();
 
     test.equal(actual, expected, 'Should generate a JSON file with default options');
 
@@ -45,8 +45,8 @@ exports.hashify = {
     test.done();
   },
   raw: function(test) {
-    var actual = grunt.file.read('tmp/raw.json');
-    var expected = grunt.file.read('test/expected/raw.json');
+    var actual = grunt.file.read('tmp/raw.json').toUpperCase();
+    var expected = grunt.file.read('test/expected/raw.json').toUpperCase();
 
     test.equal(actual, expected, 'Should generate a JSON file for raw content');
     test.done();


### PR DESCRIPTION
thank you for this hashify task plugin,but in my project ,md5 use uppercase,so i add this feature,
